### PR TITLE
Implemented method to clean up

### DIFF
--- a/Logging/include/Logging.hpp
+++ b/Logging/include/Logging.hpp
@@ -75,6 +75,7 @@ namespace Log
             Logging(std::string fullName);
 
             void createChild(std::string name);
+            void clean();
             void pullProperties();
             void pushProperties();
 
@@ -85,8 +86,6 @@ namespace Log
             void setParent(Logging *parent);
 
             // Getters
-            std::shared_ptr<Logging> getPointer()
-            { return shared_from_this(); };
             std::string getName()
             { return _name; };
             std::string getFullName()
@@ -97,7 +96,11 @@ namespace Log
             { return _format; };
             std::string getFormatTime()
             { return _formatTime; };
+            int getChildrenCnt()
+            { return _children.size(); };
             std::shared_ptr<Logging> getChild(std::string name);
+            std::shared_ptr<Logging> operator[](std::string name)
+            { return getChild(name); };
 
             // Methods to actually log messages
             void log(int level, std::string msg);

--- a/Logging/src/Logging.cpp
+++ b/Logging/src/Logging.cpp
@@ -52,6 +52,27 @@ void Log::Logging::createChild(std::string name)
     Log::Logging::_children[name] = tmpLog;
 }
 
+// Remove child loggers who are not referred to recursively
+void Log::Logging::clean()
+{
+    vector<string> deadChildrenKeys;
+    // Check if any children should be removed
+    // Flagging is done by adding their key to "deadChildrenKeys"
+    auto it = Log::Logging::_children.begin();
+    while (it != Log::Logging::_children.end()) {
+        it->second->clean();
+        // Flag child if only parent is pointing to child and child does not have children
+        if (it->second.use_count() < 2 && it->second->getChildrenCnt() == 0) {
+            deadChildrenKeys.push_back(it->first);
+        }
+        it++;
+    }
+    // Remove flagged children
+    for (auto key : deadChildrenKeys) {
+        Log::Logging::_children.erase(key);
+    }
+}
+
 // Get properties from parent logger
 void Log::Logging::pullProperties()
 {


### PR DESCRIPTION
* The logging tree can now clean itself without needing to destruct everything
* Yet another commit to fix broken links in the markdown file